### PR TITLE
AppInfo now accepts a default appCast url which can later be overridden when calling one of the check for updates methods.

### DIFF
--- a/src/Magpie/Magpie.Example/MainWindow.xaml.cs
+++ b/src/Magpie/Magpie.Example/MainWindow.xaml.cs
@@ -8,16 +8,19 @@ namespace Magpie.Example
         public MainWindow()
         {
             InitializeComponent();
-            var appInfo = new AppInfo();
-            appInfo.SetAppIcon("Magpie.Example", "logo64x64.tiff");
-            new MagpieService(appInfo).CheckInBackground("https://dl.dropboxusercontent.com/u/83257/Updaters/Magpie/appcast.json");
+            new MagpieService(MakeAppInfo()).CheckInBackground();
         }
 
         private void ForceCheck_OnClick(object sender, RoutedEventArgs e)
         {
-            var appInfo = new AppInfo();
+            new MagpieService(MakeAppInfo()).ForceCheckInBackground();
+        }
+
+        private static AppInfo MakeAppInfo()
+        {
+            var appInfo = new AppInfo("https://dl.dropboxusercontent.com/u/83257/Updaters/Magpie/appcast.json");
             appInfo.SetAppIcon("Magpie.Example", "logo64x64.tiff");
-            new MagpieService(appInfo).ForceCheckInBackground("https://dl.dropboxusercontent.com/u/83257/Updaters/Magpie/appcast.json");
+            return appInfo;
         }
     }
 }

--- a/src/Magpie/Magpie.Tests/MainWindowViewModelTests.cs
+++ b/src/Magpie/Magpie.Tests/MainWindowViewModelTests.cs
@@ -21,7 +21,7 @@ namespace Magpie.Tests
             var debuggingInfoLogger = Substitute.For<IDebuggingInfoLogger>();
             _analyticsLogger = Substitute.For<IAnalyticsLogger>();
             var remoteContentDownloader = Substitute.For<IRemoteContentDownloader>();
-            var appInfo = new AppInfo();
+            var appInfo = new AppInfo("valid_url");
             _appCast = new MockRemoteAppcast(new Version(1, 0));
             _mainWindowViewModel = new MockMainWindowViewModel(appInfo, debuggingInfoLogger, remoteContentDownloader, _analyticsLogger);
         }

--- a/src/Magpie/Magpie.Tests/Mocks/MockMagpieService.cs
+++ b/src/Magpie/Magpie.Tests/Mocks/MockMagpieService.cs
@@ -10,15 +10,16 @@ namespace Magpie.Tests.Mocks
     {
         private const string VALID_JSON = @"{ 'title': 'Magpie', 'version': '0.0.1', 'build_date': '10/03/2015', 'release_notes_url': '', 'artifact_url': 'https://dl.dropboxusercontent.com/u/83257/Updaters/Magpie/appcast.zip' }";
         internal RemoteAppcast RemoteAppcast { get; private set; }
-        internal bool ShowUpdateWindowFlag;
-        internal bool ShowNoUpdatesWindowFlag;
+        internal bool _showUpdateWindowFlag;
+        internal bool _showNoUpdatesWindowFlag;
+        internal IRemoteContentDownloader _remoteContentDownloader;
 
-        public MockMagpieService(string validUrl, IDebuggingInfoLogger infoLogger = null) : base(new AppInfo(), infoLogger)
+        public MockMagpieService(string validUrl, IDebuggingInfoLogger infoLogger = null) : base(new AppInfo(validUrl), infoLogger)
         {
             var validJson = VALID_JSON.Replace("'", "\"");
-            var downloader = Substitute.For<IRemoteContentDownloader>();
-            downloader.DownloadStringContent(validUrl).Returns(Task.FromResult(validJson));
-            base.RemoteContentDownloader = downloader;
+            _remoteContentDownloader = Substitute.For<IRemoteContentDownloader>();
+            _remoteContentDownloader.DownloadStringContent(validUrl).Returns(Task.FromResult(validJson));
+            base.RemoteContentDownloader = _remoteContentDownloader;
         }
 
         protected override void OnRemoteAppcastAvailableEvent(SingleEventArgs<RemoteAppcast> args)
@@ -30,13 +31,13 @@ namespace Magpie.Tests.Mocks
         protected override void ShowUpdateWindow(RemoteAppcast appcast)
         {
             // can't do in tests
-            ShowUpdateWindowFlag = true;
+            _showUpdateWindowFlag = true;
         }
 
         protected override void ShowNoUpdatesWindow()
         {
             // can't do in tests
-            ShowNoUpdatesWindowFlag = true;
+            _showNoUpdatesWindowFlag = true;
         }
     }
 }

--- a/src/Magpie/Magpie.Tests/Mocks/MockRemoteAppcast.cs
+++ b/src/Magpie/Magpie.Tests/Mocks/MockRemoteAppcast.cs
@@ -9,6 +9,5 @@ namespace Magpie.Tests.Mocks
         {
             Version = version;
         }
-
     }
 }

--- a/src/Magpie/Magpie.nuspec
+++ b/src/Magpie/Magpie.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Magpie</id>
-    <version>1.0.0-beta</version>
+    <version>1.0.1-beta</version>
     <authors>MetaGeek, LLC</authors>
     <projectUrl>https://github.com/metageek-llc/Magpie</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -12,6 +12,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Magpie\bin\x86\Release\Magpie.dll" target="lib\Magpie.dll" />
+    <file src="Magpie\bin\Release\Magpie.dll" target="lib\Magpie.dll" />
   </files>
 </package>

--- a/src/Magpie/Magpie/Interfaces/IAnalyticsLogger.cs
+++ b/src/Magpie/Magpie/Interfaces/IAnalyticsLogger.cs
@@ -37,8 +37,8 @@
         /// <summary>
         /// Log the name of the application to be updated.
         /// </summary>
-        /// <param name="mySuperAwesomeApp">Application name</param>
-        void LogAppTitle(string mySuperAwesomeApp);
+        /// <param name="appName">Application name</param>
+        void LogAppTitle(string appName);
 
         /// <summary>
         /// Log analytics when the user cancels the update.

--- a/src/Magpie/Magpie/Services/AnalyticsLogger.cs
+++ b/src/Magpie/Magpie/Services/AnalyticsLogger.cs
@@ -4,35 +4,35 @@ namespace Magpie.Services
 {
     public class AnalyticsLogger : IAnalyticsLogger
     {
-        public void LogDownloadNow()
+        public virtual void LogDownloadNow()
         {
         }
 
-        public void LogSkipThisVersion()
+        public virtual void LogSkipThisVersion()
         {
         }
 
-        public void LogRemindMeLater()
+        public virtual void LogRemindMeLater()
         {
         }
 
-        public void LogContinueWithInstallation()
+        public virtual void LogContinueWithInstallation()
         {
         }
 
-        public void LogOldVersion(string oldVersion)
+        public virtual void LogOldVersion(string oldVersion)
         {
         }
 
-        public void LogNewVersion(string s)
+        public virtual void LogNewVersion(string s)
         {
         }
 
-        public void LogAppTitle(string mySuperAwesomeApp)
+        public virtual void LogAppTitle(string mySuperAwesomeApp)
         {
         }
 
-        public void LogUpdateCancelled()
+        public virtual void LogUpdateCancelled()
         {
         }
     }

--- a/src/Magpie/Magpie/Services/AppInfo.cs
+++ b/src/Magpie/Magpie/Services/AppInfo.cs
@@ -1,12 +1,24 @@
+using System;
+
 namespace Magpie.Services
 {
     public class AppInfo
     {
         public string AppIconPath { get; set; }
+        public string AppCastUrl { get; set; }
 
         public void SetAppIcon(string imageNamespace, string imagePath)
         {
             AppIconPath = string.Format("pack://application:,,,/{0};component/{1}", imageNamespace, imagePath);
+        }
+
+        public AppInfo(string appCastUrl)
+        {
+            if (string.IsNullOrWhiteSpace(appCastUrl))
+            {
+                throw new ArgumentNullException("appCastUrl");
+            }
+            AppCastUrl = appCastUrl;
         }
     }
 }

--- a/src/Magpie/Magpie/Services/MagpieService.cs
+++ b/src/Magpie/Magpie/Services/MagpieService.cs
@@ -16,7 +16,7 @@ namespace Magpie.Services
     {
         private readonly AppInfo _appInfo;
         private readonly IDebuggingInfoLogger _logger;
-        private IAnalyticsLogger _analyticsLogger;
+        private readonly IAnalyticsLogger _analyticsLogger;
         internal UpdateDecider UpdateDecider { get; set; }
         internal IRemoteContentDownloader RemoteContentDownloader { get; set; }
         public event EventHandler<SingleEventArgs<RemoteAppcast>> RemoteAppcastAvailableEvent;

--- a/src/Magpie/Magpie/Services/MagpieService.cs
+++ b/src/Magpie/Magpie/Services/MagpieService.cs
@@ -31,14 +31,14 @@ namespace Magpie.Services
             UpdateDecider = new UpdateDecider(_logger);
         }
 
-        public async void CheckInBackground(string appcastUrl, bool showDebuggingWindow = false)
+        public async void CheckInBackground(string appcastUrl = null, bool showDebuggingWindow = false)
         {
-            await Check(appcastUrl, showDebuggingWindow).ConfigureAwait(false);
+            await Check(appcastUrl ?? _appInfo.AppCastUrl, showDebuggingWindow).ConfigureAwait(false);
         }
 
-        public async void ForceCheckInBackground(string appcastUrl, bool showDebuggingWindow = false)
+        public async void ForceCheckInBackground(string appcastUrl = null, bool showDebuggingWindow = false)
         {
-            await Check(appcastUrl, showDebuggingWindow, true).ConfigureAwait(false);
+            await Check(appcastUrl ?? _appInfo.AppCastUrl, showDebuggingWindow, true).ConfigureAwait(false);
         }
 
         private async Task Check(string appcastUrl, bool showDebuggingWindow = false, bool forceCheck = false)


### PR DESCRIPTION
 The url can later be overridden when calling one of the check for updates methods.
